### PR TITLE
Add RTF preview and conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,21 @@ Open the Community Plugins tab in the settings and search for "Docxer" (or click
     </ul>
 </details>
 
+## Supported Files
+
+- `.docx`
+- `.rtf`
+- `.rtf.doc`
+- `.doc` files that are actually RTF content
+
+Old binary Microsoft Word `.doc` files are not converted. When a `.doc` file does not start with RTF data, Docxer shows a warning instead of trying to parse it.
+
 ## Usage
-1. Add a .docx file to your vault.
+1. Add a supported document file to your vault.
 2. Open the file in Obsidian.
 3. Click the "Convert" button in the top right corner of the editor to convert the file to markdown.
+
+For files named like `NLC Tasks.rtf.doc`, conversion creates `NLC Tasks.md`.
 
 ## Support
 Please consider supporting the plugin. The two easiest ways to support the plugin are either by starring ⭐ the repository or by donating any amount on [Ko-fi](https://ko-fi.com/X8X27IA08) ❤️. Thank you!
@@ -46,7 +57,9 @@ Please consider supporting the plugin. The two easiest ways to support the plugi
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/X8X27IA08)
 
 ## Implementation
-Docxer uses [docx-preview](https://www.npmjs.com/package/docx-preview) to render the previews, [mammoth](https://www.npmjs.com/package/mammoth) to convert `docx` to `HTML` and [turndown](https://www.npmjs.com/package/turndown) to finally convert the `HTML` to Markdown.
+Docxer uses [docx-preview](https://www.npmjs.com/package/docx-preview) to render DOCX previews, [mammoth](https://www.npmjs.com/package/mammoth) to convert `docx` to `HTML` and [turndown](https://www.npmjs.com/package/turndown) to finally convert the `HTML` to Markdown.
+
+RTF support uses a local parser in `src/utils/rtf-utils.ts`. It focuses on readable text conversion for common RTF files and handles line breaks, tabs, encoded characters, bullets, and RTF-backed `.doc` files.
 
 ## Screenshots
 ![Docx Preview](assets/docx-preview.png)

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,8 @@
 	"name": "Docxer",
 	"version": "2.3.1",
 	"minAppVersion": "1.5.0",
-	"description": "Import Word files easily. Adds a preview mode for .docx files and the ability to convert them to markdown (.md) files.",
+	"main": "main.js",
+	"description": "Import Word and RTF files easily. Adds preview modes for .docx, .rtf, and RTF-backed .doc files with conversion to markdown (.md).",
 	"author": "Developer-Mike",
 	"authorUrl": "https://github.com/Developer-Mike",
 	"isDesktopOnly": false

--- a/src/convertable-file-views/rtf.ts
+++ b/src/convertable-file-views/rtf.ts
@@ -1,0 +1,50 @@
+import { MarkdownRenderer, Notice, TFile } from "obsidian"
+import ConvertibleFileView from "src/core/convertible-file-view"
+import RtfUtils from "src/utils/rtf-utils"
+
+export default class RtfFileView extends ConvertibleFileView {
+  static readonly VIEW_TYPE_ID = "docxer-plus-rtf-view"
+
+  getViewType(): string {
+    return RtfFileView.VIEW_TYPE_ID
+  }
+
+  async getFilePreview(): Promise<HTMLElement | null> {
+    if (!this.file) return null
+
+    const content = await this.app.vault.read(this.file)
+    const wrapper = document.createElement("div")
+    wrapper.classList.add("rtf-preview")
+
+    if (!RtfUtils.isRtf(content)) {
+      wrapper.createEl("p", {
+        text: "This .doc file does not look like an RTF document. Docxer Plus can read .rtf files and .doc files whose content starts with RTF data.",
+      })
+      return wrapper
+    }
+
+    const markdown = RtfUtils.toMarkdown(content)
+    await MarkdownRenderer.render(this.app, markdown, wrapper, this.file.path, this)
+    return wrapper
+  }
+
+  async getMarkdownContent(_attachmentsDirectory: string): Promise<string | null> {
+    if (!this.file) return null
+
+    const content = await this.app.vault.read(this.file)
+    if (!RtfUtils.isRtf(content)) {
+      new Notice("This .doc file is not an RTF document.")
+      return null
+    }
+
+    return RtfUtils.toMarkdown(content)
+  }
+
+  protected getConvertedFilePath(file: TFile): string {
+    if (file.path.toLowerCase().endsWith(".rtf.doc")) {
+      return file.path.slice(0, -".rtf.doc".length) + ".md"
+    }
+
+    return super.getConvertedFilePath(file)
+  }
+}

--- a/src/core/convertible-file-view.ts
+++ b/src/core/convertible-file-view.ts
@@ -66,13 +66,17 @@ export default abstract class ConvertibleFileView extends EditableFileView {
 
 	getViewData(): string {
     return this.fileContent
-	}
+  }
 
   abstract getMarkdownContent(attachmentsDirectory: string): Promise<string | null>
+  protected getConvertedFilePath(file: TFile): string {
+    return FileUtils.toUnixPath(file.path).replace(/\.[^\.]*$/, ".md")
+  }
+
   private async convertFile() {
     if (!this.file) return
 
-    const convertedFilePath = FileUtils.toUnixPath(this.file.path).replace(/\.[^\.]*$/, ".md")
+    const convertedFilePath = this.getConvertedFilePath(this.file)
     if (this.app.vault.getAbstractFileByPath(convertedFilePath)) {
       new Notice("A file with the same name already exists.")
       return

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,14 @@
 import DocxFileView from "./convertable-file-views/docx"
+import RtfFileView from "./convertable-file-views/rtf"
 import ConvertibleFileView from "./core/convertible-file-view"
 import DocxerEmbedComponent from "./core/docxer-embed-component"
 import SettingsManager from "./settings"
-import { Plugin, TFile, WorkspaceLeaf } from "obsidian"
+import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian"
 
 export const FILETYPE_MAP: { [key: string]: new(leaf: WorkspaceLeaf, plugin: DocxerPlugin) => ConvertibleFileView } = {
-  "docx": DocxFileView
+  "docx": DocxFileView,
+  "rtf": RtfFileView,
+  "doc": RtfFileView,
 }
 
 export default class DocxerPlugin extends Plugin {
@@ -16,15 +19,33 @@ export default class DocxerPlugin extends Plugin {
     await this.settings.loadSettings()
     this.settings.addSettingsTab()
 
+    const registeredViewTypes = new Set<string>()
+
     for (const [fileExtension, viewClass] of Object.entries(FILETYPE_MAP)) {
-      this.registerView((viewClass as any).VIEW_TYPE_ID, (leaf) => new viewClass(leaf, this))
-      this.registerExtensions([fileExtension], (viewClass as any).VIEW_TYPE_ID)
+      const viewTypeId = (viewClass as any).VIEW_TYPE_ID
+
+      try {
+        if (!registeredViewTypes.has(viewTypeId)) {
+          this.registerView(viewTypeId, (leaf) => new viewClass(leaf, this))
+          registeredViewTypes.add(viewTypeId)
+        }
+
+        this.registerExtensions([fileExtension], viewTypeId)
+      } catch (error) {
+        console.error(`Docxer Plus could not register .${fileExtension} support`, error)
+        new Notice(`Docxer Plus could not register .${fileExtension} support. Check the developer console for details.`)
+        continue
+      }
 
       // Register embeds
       if (!DocxerEmbedComponent.isEmbeddable(viewClass)) continue
 
-      ;(this.app as any).embedRegistry.unregisterExtension(fileExtension)
-      ;(this.app as any).embedRegistry.registerExtension(fileExtension, (info: any, file: TFile, subpath: string) => new DocxerEmbedComponent(this, viewClass, info, file, subpath))
+      try {
+        ;(this.app as any).embedRegistry.unregisterExtension(fileExtension)
+        ;(this.app as any).embedRegistry.registerExtension(fileExtension, (info: any, file: TFile, subpath: string) => new DocxerEmbedComponent(this, viewClass, info, file, subpath))
+      } catch (error) {
+        console.error(`Docxer Plus could not register .${fileExtension} embeds`, error)
+      }
     }
 	}
 

--- a/src/utils/rtf-utils.ts
+++ b/src/utils/rtf-utils.ts
@@ -1,0 +1,208 @@
+export default class RtfUtils {
+  static isRtf(content: string): boolean {
+    return content.trimStart().startsWith("{\\rtf")
+  }
+
+  static toMarkdown(content: string): string {
+    const parser = new RtfMarkdownParser(content)
+    return RtfUtils.cleanupMarkdown(parser.parse())
+  }
+
+  private static cleanupMarkdown(markdown: string): string {
+    return markdown
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+      + "\n"
+  }
+}
+
+type ParserState = {
+  skip: boolean
+  uc: number
+}
+
+class RtfMarkdownParser {
+  private index = 0
+  private output = ""
+  private state: ParserState = { skip: false, uc: 1 }
+  private stack: ParserState[] = []
+  private charsToSkip = 0
+
+  private readonly skippableDestinations = new Set([
+    "fonttbl",
+    "colortbl",
+    "stylesheet",
+    "info",
+    "pict",
+    "object",
+    "generator",
+    "mmathPr",
+    "fldinst",
+    "datastore",
+    "themedata",
+  ])
+
+  constructor(private readonly input: string) {}
+
+  parse(): string {
+    while (this.index < this.input.length) {
+      const char = this.input[this.index]
+
+      if (this.charsToSkip > 0) {
+        this.charsToSkip--
+        this.index++
+        continue
+      }
+
+      if (char === "{") {
+        this.stack.push({ ...this.state })
+        this.index++
+        continue
+      }
+
+      if (char === "}") {
+        this.state = this.stack.pop() ?? this.state
+        this.index++
+        continue
+      }
+
+      if (char === "\\") {
+        this.readControl()
+        continue
+      }
+
+      this.append(char)
+      this.index++
+    }
+
+    return this.output
+  }
+
+  private readControl(): void {
+    this.index++
+    const controlStart = this.index
+    const first = this.input[this.index]
+
+    if (first === "'") {
+      this.index++
+      const hex = this.input.slice(this.index, this.index + 2)
+      this.index += 2
+      this.append(this.decodeHex(hex))
+      return
+    }
+
+    if (!/[a-zA-Z*~{}\\_-]/.test(first ?? "")) {
+      this.index++
+      return
+    }
+
+    if (!/[a-zA-Z]/.test(first ?? "")) {
+      this.handleSymbol(first)
+      this.index++
+      return
+    }
+
+    while (/[a-zA-Z]/.test(this.input[this.index] ?? "")) this.index++
+    const word = this.input.slice(controlStart, this.index)
+
+    let parameter: number | null = null
+    let sign = 1
+    if (this.input[this.index] === "-") {
+      sign = -1
+      this.index++
+    }
+
+    const parameterStart = this.index
+    while (/[0-9]/.test(this.input[this.index] ?? "")) this.index++
+    if (this.index > parameterStart) {
+      parameter = Number(this.input.slice(parameterStart, this.index)) * sign
+    }
+
+    if (this.input[this.index] === " ") this.index++
+    this.handleControlWord(word, parameter)
+  }
+
+  private handleSymbol(symbol: string): void {
+    if (this.state.skip) return
+
+    switch (symbol) {
+      case "~":
+        this.output += " "
+        break
+      case "_":
+        this.output += "-"
+        break
+      case "{":
+      case "}":
+      case "\\":
+        this.output += symbol
+        break
+    }
+  }
+
+  private handleControlWord(word: string, parameter: number | null): void {
+    if (this.skippableDestinations.has(word)) {
+      this.state.skip = true
+      return
+    }
+
+    if (this.state.skip) return
+
+    switch (word) {
+      case "par":
+      case "sect":
+        this.output += "\n\n"
+        break
+      case "line":
+        this.output += "\n"
+        break
+      case "tab":
+        this.output += "\t"
+        break
+      case "emdash":
+        this.output += "--"
+        break
+      case "endash":
+        this.output += "-"
+        break
+      case "bullet":
+        this.output += "- "
+        break
+      case "u":
+        if (parameter !== null) {
+          this.appendUnicode(parameter)
+          this.charsToSkip = this.state.uc
+        }
+        break
+      case "uc":
+        this.state.uc = parameter ?? 1
+        break
+    }
+  }
+
+  private append(text: string): void {
+    if (this.state.skip) return
+    this.output += text
+  }
+
+  private appendUnicode(value: number): void {
+    const codePoint = value < 0 ? value + 65536 : value
+    this.output += String.fromCharCode(codePoint)
+  }
+
+  private decodeHex(hex: string): string {
+    const value = parseInt(hex, 16)
+    if (Number.isNaN(value)) return ""
+
+    const cp1252: Record<number, string> = {
+      0x80: "EUR", 0x82: "'", 0x83: "f", 0x84: "\"", 0x85: "...", 0x86: "+", 0x87: "++",
+      0x88: "^", 0x89: "%", 0x8a: "S", 0x8b: "<", 0x8c: "OE", 0x8e: "Z",
+      0x91: "'", 0x92: "'", 0x93: "\"", 0x94: "\"", 0x95: "*", 0x96: "-", 0x97: "--",
+      0x98: "~", 0x99: "TM", 0x9a: "s", 0x9b: ">", 0x9c: "oe", 0x9e: "z", 0x9f: "Y",
+    }
+
+    if (cp1252[value]) return cp1252[value]
+    return String.fromCharCode(value)
+  }
+}


### PR DESCRIPTION
 ## What changed

  This adds basic RTF support to Docxer.

  The plugin can now preview and convert:

  - `.rtf`
  - `.rtf.doc`
  - `.doc` files that are actually RTF content

  Old binary `.doc` files are not converted. If a `.doc` file does not start with RTF data, the plugin shows a warning
  instead of trying to parse it.

  ## Why

  I made this while helping my wife move from WordPad to Obsidian. She has over 100 RTF files, and I liked how easy
  Docxer made the DOCX workflow, so I wanted to see if the same kind of flow could work for her old RTF files too.

  This fits my use case and has worked well in local testing. No worries if it does not fit the direction of the plugin,
  but I figured it might help someone else with a similar migration.

  ## Notes

  RTF support uses a small local parser focused on readable text conversion. It handles common RTF text, line breaks,
  tabs, encoded characters, bullets, and RTF-backed `.doc` files.

  ## Testing

  - Ran `npm.cmd run build`
  - Tested preview/conversion locally with RTF files