### PR TITLE
Remember preview scroll position

### DIFF
--- a/src/core/convertible-file-view.ts
+++ b/src/core/convertible-file-view.ts
@@ -7,6 +7,11 @@ export default abstract class ConvertibleFileView extends EditableFileView {
   fileContent: string
   header: HTMLElement | null = null
   content: HTMLElement | null = null
+  private pendingScrollTop: number | null = null
+  private lastKnownScrollTop: number | null = null
+  private restoreScrollPositionFrame: number | null = null
+  private restoreScrollPositionTimeout: number | null = null
+  private saveScrollPositionTimeout: number | null = null
 
 	constructor(leaf: WorkspaceLeaf, plugin: DocxerPlugin) {
 		super(leaf)
@@ -23,6 +28,8 @@ export default abstract class ConvertibleFileView extends EditableFileView {
 
   async onOpen() {
 		await super.onOpen()
+
+    this.contentEl.addEventListener("scroll", this.onScroll)
 
     this.header = document.createElement("div")
     this.header.id = "docxer-header"
@@ -41,22 +48,126 @@ export default abstract class ConvertibleFileView extends EditableFileView {
   }
 
 	async onClose() {
+    this.cancelScrollRestoration()
+    this.contentEl.removeEventListener("scroll", this.onScroll)
 		await super.onClose()
     if (this.header) this.header.remove()
 	}
 
   abstract getFilePreview(): Promise<HTMLElement | null>
 	async onLoadFile(file: TFile) {
+		const persistedScrollTop = this.plugin.settings.getScrollPosition(file.path)
 		await super.onLoadFile(file)
 
+    if (this.pendingScrollTop === null)
+      this.pendingScrollTop = persistedScrollTop
+    this.lastKnownScrollTop = this.pendingScrollTop ?? 0
+
     this.content = await this.getFilePreview()
-    if (this.content) this.contentEl.appendChild(this.content)
+    if (this.content) {
+      this.contentEl.appendChild(this.content)
+      this.restoreScrollPosition()
+    }
 	}
 
 	async onUnloadFile(file: TFile) {
+		await this.persistScrollPosition(file)
 		await super.onUnloadFile(file)
     if (this.content) this.content.remove()
 	}
+
+  getEphemeralState(): Record<string, unknown> {
+    return {
+      ...super.getEphemeralState(),
+      scrollTop: this.contentEl.scrollTop,
+    }
+  }
+
+  setEphemeralState(state: unknown): void {
+    super.setEphemeralState(state)
+
+    if (!state || typeof state !== "object" || !("scrollTop" in state)) return
+
+    const scrollTop = (state as Record<string, unknown>).scrollTop
+    if (typeof scrollTop !== "number" || !Number.isFinite(scrollTop) || scrollTop < 0) return
+
+    this.pendingScrollTop = scrollTop
+    this.lastKnownScrollTop = scrollTop
+    this.restoreScrollPosition()
+  }
+
+  private restoreScrollPosition(): void {
+    if (this.pendingScrollTop === null || !this.content) return
+
+    const scrollTop = this.pendingScrollTop
+    const content = this.content
+    const win = this.contentEl.ownerDocument.defaultView ?? window
+    this.cancelScrollRestoration()
+
+    const apply = () => {
+      if (this.pendingScrollTop !== scrollTop || this.content !== content) return
+
+      this.cancelScrollRestoration()
+      this.contentEl.scrollTop = scrollTop
+      this.lastKnownScrollTop = this.contentEl.scrollTop
+      this.pendingScrollTop = null
+    }
+
+    const restore = () => {
+      this.restoreScrollPositionTimeout = null
+      if (this.pendingScrollTop !== scrollTop || this.content !== content) return
+      if (!content.isConnected) {
+        this.restoreScrollPositionTimeout = win.setTimeout(restore, 50)
+        return
+      }
+
+      this.restoreScrollPositionFrame = win.requestAnimationFrame(apply)
+      this.restoreScrollPositionTimeout = win.setTimeout(apply, 100)
+    }
+
+    this.restoreScrollPositionTimeout = win.setTimeout(restore, 0)
+  }
+
+  private cancelScrollRestoration(): void {
+    const win = this.contentEl.ownerDocument.defaultView ?? window
+    if (this.restoreScrollPositionFrame !== null) {
+      win.cancelAnimationFrame(this.restoreScrollPositionFrame)
+      this.restoreScrollPositionFrame = null
+    }
+    if (this.restoreScrollPositionTimeout !== null) {
+      win.clearTimeout(this.restoreScrollPositionTimeout)
+      this.restoreScrollPositionTimeout = null
+    }
+  }
+
+  private onScroll = (): void => {
+    if (!this.file || !this.content?.isConnected) return
+
+    const scrollTop = this.contentEl.scrollTop
+    this.lastKnownScrollTop = scrollTop
+    this.plugin.settings.setScrollPosition(this.file.path, scrollTop)
+
+    const win = this.contentEl.ownerDocument.defaultView ?? window
+    if (this.saveScrollPositionTimeout !== null)
+      win.clearTimeout(this.saveScrollPositionTimeout)
+
+    this.saveScrollPositionTimeout = win.setTimeout(() => {
+      this.saveScrollPositionTimeout = null
+      void this.plugin.settings.saveSettings()
+    }, 500)
+  }
+
+  private async persistScrollPosition(file: TFile): Promise<void> {
+    const win = this.contentEl.ownerDocument.defaultView ?? window
+    if (this.saveScrollPositionTimeout !== null) {
+      win.clearTimeout(this.saveScrollPositionTimeout)
+      this.saveScrollPositionTimeout = null
+    }
+
+    const scrollTop = this.lastKnownScrollTop ?? this.contentEl.scrollTop
+    this.plugin.settings.setScrollPosition(file.path, scrollTop)
+    await this.plugin.settings.saveSettings()
+  }
 
 	clear(): void {}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface DocxerPluginSettings {
   attachmentsFolder: "vault" | "custom" | "same" | "subfolder"
   customAttachmentsFolder: string
   useImageAltAsFilename: boolean
+  scrollPositions: Record<string, number>
 }
 
 export const DEFAULT_SETTINGS: Partial<DocxerPluginSettings> = {
@@ -21,6 +22,7 @@ export const DEFAULT_SETTINGS: Partial<DocxerPluginSettings> = {
   attachmentsFolder: "subfolder",
   customAttachmentsFolder: "Attachments",
   useImageAltAsFilename: false,
+  scrollPositions: {},
 }
 
 export default class SettingsManager {
@@ -45,6 +47,25 @@ export default class SettingsManager {
 
   getSetting<T extends keyof DocxerPluginSettings>(key: T): DocxerPluginSettings[T] {
     return this.settings[key]
+  }
+
+  getScrollPosition(filePath: string): number | null {
+    const scrollPositions = this.settings.scrollPositions
+    if (!scrollPositions || typeof scrollPositions !== "object") return null
+
+    const scrollTop = scrollPositions[filePath]
+    if (typeof scrollTop !== "number" || !Number.isFinite(scrollTop) || scrollTop < 0) return null
+
+    return scrollTop
+  }
+
+  setScrollPosition(filePath: string, scrollTop: number): void {
+    if (!Number.isFinite(scrollTop) || scrollTop < 0) return
+
+    if (!this.settings.scrollPositions || typeof this.settings.scrollPositions !== "object")
+      this.settings.scrollPositions = {}
+
+    this.settings.scrollPositions[filePath] = scrollTop
   }
 
   async setSetting(data: Partial<DocxerPluginSettings>) {


### PR DESCRIPTION
## Summary

Docxer discarded the preview scroll position because it rebuilt the preview DOM whenever a file loaded without participating in Obsidian's ephemeral view-state lifecycle or storing a durable per-file position.

This change captures the preview container's scroll offset in ephemeral state for Back/Forward navigation and in plugin data for reopening a tab or restarting Obsidian. Restored values are validated, restoration remains queued until the asynchronously rendered preview is attached, and durable positions are debounced while scrolling and flushed when the view unloads.

## User impact

Returning to a DOCX preview now restores the previous reading location across navigation, tab closure, and Obsidian restarts.

## Validation

- `npm ci`
- `npm run build`
- `npx tsc --noEmit`
- `git diff upstream/main...HEAD --check`

Interactive Obsidian validation confirmed restoration through Back navigation, tab close/reopen, and a full Obsidian restart. The runtime checks restored the exact captured offsets in all three cases.
